### PR TITLE
make decoder / encoder types concrete

### DIFF
--- a/src/atdgen_codec_runtime.mli
+++ b/src/atdgen_codec_runtime.mli
@@ -10,7 +10,7 @@ end
 
 module Encode : sig
 
-  type 'a t = 'a Json_encode.encoder
+  type 'a t = 'a -> Js.Json.t
 
   val make : ('a -> Json.t) -> 'a t
 
@@ -53,7 +53,7 @@ end
 
 module Decode : sig
 
-  type 'a t = 'a Json_decode.decoder
+  type 'a t = Js.Json.t -> 'a
 
   val make : (Json.t -> 'a) -> 'a t
 


### PR DESCRIPTION
This PR exposes the concrete signatures of`Encode.t` and `Decode.t` types. This fixes an obscure type error when code generating (de)serializers for recursively defined variant types. See issue https://github.com/mjambon/atd/issues/152#issuecomment-435476488 for more details.

I am open to other ways to fix this as well but I know this solution resolves it, at least.

