### PR TITLE
Upgrade bs platform 5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "bs-platform": "^5.0.6"
   },
   "dependencies": {
-    "@glennsl/bs-json": "^3.0.0"
+    "@glennsl/bs-json": "^4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
   },
   "devDependencies": {
     "@glennsl/bs-jest": "^0.4.3",
-    "bs-platform": "^4.0.5"
+    "bs-platform": "^5.0.6"
   },
   "peerDependencies": {
-    "bs-platform": "^4.0.5"
+    "bs-platform": "^5.0.6"
   },
   "dependencies": {
     "@glennsl/bs-json": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
   },
   "devDependencies": {
     "@glennsl/bs-jest": "^0.4.3",
-    "bs-platform": "^5.0.6"
+    "bs-platform": ">= 4.0.0"
   },
   "peerDependencies": {
-    "bs-platform": "^5.0.6"
+    "bs-platform": ">= 4.0.0"
   },
   "dependencies": {
-    "@glennsl/bs-json": "^4.0.0"
+    "@glennsl/bs-json": ">= 3.0.0"
   }
 }


### PR DESCRIPTION
Hi, the current version of this package emits npm peer dependency warnings when used in projects that use bs-platform `5.x`.

This MR upgrades bs-platform to `^5.0.6` and `@glennsl/bs-json` to `^4.0.0` (which is bs-platform `5.x` compatible -- see changelog here: https://github.com/glennsl/bs-json#400).

If this looks good to you, would appreciate a major bump on npm to `2.0.0`. Thanks!