### PR TITLE
Fix version range for bs-json dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "bs-platform": ">= 4.0.0"
   },
   "dependencies": {
-    "@glennsl/bs-json": ">= 3.0.0"
+    "@glennsl/bs-json": ">=3.0.0 <5.0.0"
   }
 }


### PR DESCRIPTION
The current version won't build with bs-json 5.0.0.