### PR TITLE
Fix a bug in deserialization with custom Type_field adapter

### DIFF
--- a/__tests__/kind_field.ml
+++ b/__tests__/kind_field.ml
@@ -1,0 +1,1 @@
+include Atdgen_codec_runtime.Json_adapter.Type_field.Make (struct let type_field_name = "kind" end)

--- a/__tests__/roundtrip_test.ml
+++ b/__tests__/roundtrip_test.ml
@@ -90,6 +90,16 @@ let () =
       ~read:Test_bs.read_adapted
       ~data:Test_t.(`B {thing = 1;});
     run_test
+      ~name:"adapter kind field - variant 1"
+      ~write:Test_bs.write_adapted_kind
+      ~read:Test_bs.read_adapted_kind
+      ~data:Test_t.(`A {thing = "thing"; other_thing = false;});
+    run_test
+      ~name:"adapter kind field - variant 2"
+      ~write:Test_bs.write_adapted_kind
+      ~read:Test_bs.read_adapted_kind
+      ~data:Test_t.(`B {thing = 1;});
+    run_test
       ~name:"int array"
       ~write:Test_bs.write_an_array
       ~read:Test_bs.read_an_array

--- a/__tests__/test.atd
+++ b/__tests__/test.atd
@@ -62,6 +62,11 @@ type adapted = [
   | B of b
 ] <json adapter.ocaml="Atdgen_codec_runtime.Json_adapter.Type_field">
 
+type adapted_kind = [
+  | A of a
+  | B of b
+] <json adapter.ocaml="Kind_field">
+
 type a = {
   thing: string;
   other_thing: bool;

--- a/__tests__/test_bs.ml
+++ b/__tests__/test_bs.ml
@@ -47,6 +47,8 @@ type an_array = Test_t.an_array
 
 type a = Test_t.a = { thing: string; other_thing: bool }
 
+type adapted_kind = Test_t.adapted_kind
+
 type adapted = Test_t.adapted
 
 let rec write__8 js = (
@@ -686,6 +688,44 @@ let read_a = (
             ) json;
       } : a)
     )
+  )
+)
+let write_adapted_kind = (
+  Atdgen_codec_runtime.Encode.adapter Kind_field.restore (
+    Atdgen_codec_runtime.Encode.make (fun (x : _) -> match x with
+      | `A x ->
+      Atdgen_codec_runtime.Encode.constr1 "A" (
+        write_a
+      ) x
+      | `B x ->
+      Atdgen_codec_runtime.Encode.constr1 "B" (
+        write_b
+      ) x
+    )
+  )
+)
+let read_adapted_kind = (
+  Atdgen_codec_runtime.Decode.adapter Kind_field.normalize (
+    Atdgen_codec_runtime.Decode.enum
+    [
+        (
+        "A"
+        ,
+          `Decode (
+          read_a
+          |> Atdgen_codec_runtime.Decode.map (fun x -> ((`A x) : _))
+          )
+        )
+      ;
+        (
+        "B"
+        ,
+          `Decode (
+          read_b
+          |> Atdgen_codec_runtime.Decode.map (fun x -> ((`B x) : _))
+          )
+        )
+    ]
   )
 )
 let write_adapted = (

--- a/__tests__/test_bs.mli
+++ b/__tests__/test_bs.mli
@@ -47,6 +47,8 @@ type an_array = Test_t.an_array
 
 type a = Test_t.a = { thing: string; other_thing: bool }
 
+type adapted_kind = Test_t.adapted_kind
+
 type adapted = Test_t.adapted
 
 val read_recurse :  recurse Atdgen_codec_runtime.Decode.t
@@ -124,6 +126,10 @@ val write_an_array :  an_array Atdgen_codec_runtime.Encode.t
 val read_a :  a Atdgen_codec_runtime.Decode.t
 
 val write_a :  a Atdgen_codec_runtime.Encode.t
+
+val read_adapted_kind :  adapted_kind Atdgen_codec_runtime.Decode.t
+
+val write_adapted_kind :  adapted_kind Atdgen_codec_runtime.Encode.t
 
 val read_adapted :  adapted Atdgen_codec_runtime.Decode.t
 

--- a/__tests__/test_t.ml
+++ b/__tests__/test_t.ml
@@ -43,4 +43,6 @@ type an_array = int Atdgen_runtime.Util.ocaml_array
 
 type a = { thing: string; other_thing: bool }
 
+type adapted_kind = [ `A of a | `B of b ]
+
 type adapted = [ `A of a | `B of b ]

--- a/__tests__/test_t.mli
+++ b/__tests__/test_t.mli
@@ -43,4 +43,6 @@ type an_array = int Atdgen_runtime.Util.ocaml_array
 
 type a = { thing: string; other_thing: bool }
 
+type adapted_kind = [ `A of a | `B of b ]
+
 type adapted = [ `A of a | `B of b ]

--- a/src/atdgen_codec_runtime.ml
+++ b/src/atdgen_codec_runtime.ml
@@ -23,7 +23,7 @@ module Json_adapter = struct
 
       let normalize (json : Json.t) =
         let open Json_decode in
-        match json |> (at ["type"] string) with
+        match json |> (at [type_field_name] string) with
         | type_ ->
             let normalized: Json.t = Obj.magic (type_, json) in
             normalized

--- a/src/atdgen_codec_runtime.mli
+++ b/src/atdgen_codec_runtime.mli
@@ -38,7 +38,7 @@ module Json_adapter: sig
 
     (** Functor, allowing the use of a custom parameter:
       {[
-      module Kind_field = Type_field.Make (struct type_field_name = "kind" end)
+      module Kind_field = Type_field.Make (struct let type_field_name = "kind" end)
       ]}
     *)
     module Make (Param : Param) : S


### PR DESCRIPTION
A custom `Type_field` adapter was always looking for `"type"` field when deserializing, rather than for the defined `type_field_name`.

* Fix the type field lookup https://github.com/ahrefs/bs-atdgen-codec-runtime/pull/15/files#diff-af319977d60814aacb356044a4666058R26
* Fix syntax error in the documentation comment https://github.com/ahrefs/bs-atdgen-codec-runtime/pull/15/files#diff-e80666c201117e21af39051ca4ec6f01R41
* Add tests for custom `<json adapter.ocaml="Kind_field">` adapter