### PR TITLE
fix Type_field adapter when variant with non-record type is used

### DIFF
--- a/__tests__/roundtrip_test.ml
+++ b/__tests__/roundtrip_test.ml
@@ -109,4 +109,19 @@ let () =
       ~write:Test_bs.write_optional_field
       ~read:Test_bs.read_optional_field
       ~data:{with_default = 1; no_default = None; no_default_nullable = Some 11};
+    run_test
+      ~name:"adapter scalar"
+      ~write:Test_bs.write_adapted_scalar
+      ~read:Test_bs.read_adapted_scalar
+      ~data:(`A 1);
+    run_test
+      ~name:"adapter scalar - variant 2"
+      ~write:Test_bs.write_adapted_scalar
+      ~read:Test_bs.read_adapted_scalar
+      ~data:(`B "thing");
+    run_test
+      ~name:"adapter list"
+      ~write:Test_bs.write_adapted_list
+      ~read:Test_bs.read_adapted_list
+      ~data:(`A [1]);
   )

--- a/__tests__/test.atd
+++ b/__tests__/test.atd
@@ -67,6 +67,15 @@ type adapted_kind = [
   | B of b
 ] <json adapter.ocaml="Kind_field">
 
+type adapted_scalar = [
+  | A of int
+  | B of string
+] <json adapter.ocaml="Atdgen_codec_runtime.Json_adapter.Type_field">
+
+type adapted_list = [
+  | A of int list
+] <json adapter.ocaml="Atdgen_codec_runtime.Json_adapter.Type_field">
+
 type a = {
   thing: string;
   other_thing: bool;

--- a/__tests__/test_bs.ml
+++ b/__tests__/test_bs.ml
@@ -45,6 +45,10 @@ type b = Test_t.b = { thing: int }
 
 type an_array = Test_t.an_array
 
+type adapted_scalar = Test_t.adapted_scalar
+
+type adapted_list = Test_t.adapted_list
+
 type a = Test_t.a = { thing: string; other_thing: bool }
 
 type adapted_kind = Test_t.adapted_kind
@@ -632,21 +636,94 @@ let read_b = (
     )
   )
 )
-let write__12 = (
+let write__13 = (
   Atdgen_codec_runtime.Encode.array (
     Atdgen_codec_runtime.Encode.int
   )
 )
-let read__12 = (
+let read__13 = (
   Atdgen_codec_runtime.Decode.array (
     Atdgen_codec_runtime.Decode.int
   )
 )
 let write_an_array = (
-  write__12
+  write__13
 )
 let read_an_array = (
-  read__12
+  read__13
+)
+let write_adapted_scalar = (
+  Atdgen_codec_runtime.Encode.adapter Atdgen_codec_runtime.Json_adapter.Type_field.restore (
+    Atdgen_codec_runtime.Encode.make (fun (x : _) -> match x with
+      | `A x ->
+      Atdgen_codec_runtime.Encode.constr1 "A" (
+        Atdgen_codec_runtime.Encode.int
+      ) x
+      | `B x ->
+      Atdgen_codec_runtime.Encode.constr1 "B" (
+        Atdgen_codec_runtime.Encode.string
+      ) x
+    )
+  )
+)
+let read_adapted_scalar = (
+  Atdgen_codec_runtime.Decode.adapter Atdgen_codec_runtime.Json_adapter.Type_field.normalize (
+    Atdgen_codec_runtime.Decode.enum
+    [
+        (
+        "A"
+        ,
+          `Decode (
+          Atdgen_codec_runtime.Decode.int
+          |> Atdgen_codec_runtime.Decode.map (fun x -> ((`A x) : _))
+          )
+        )
+      ;
+        (
+        "B"
+        ,
+          `Decode (
+          Atdgen_codec_runtime.Decode.string
+          |> Atdgen_codec_runtime.Decode.map (fun x -> ((`B x) : _))
+          )
+        )
+    ]
+  )
+)
+let write__12 = (
+  Atdgen_codec_runtime.Encode.list (
+    Atdgen_codec_runtime.Encode.int
+  )
+)
+let read__12 = (
+  Atdgen_codec_runtime.Decode.list (
+    Atdgen_codec_runtime.Decode.int
+  )
+)
+let write_adapted_list = (
+  Atdgen_codec_runtime.Encode.adapter Atdgen_codec_runtime.Json_adapter.Type_field.restore (
+    Atdgen_codec_runtime.Encode.make (fun (x : _) -> match x with
+      | `A x ->
+      Atdgen_codec_runtime.Encode.constr1 "A" (
+        write__12
+      ) x
+    )
+  )
+)
+let read_adapted_list = (
+  Atdgen_codec_runtime.Decode.adapter Atdgen_codec_runtime.Json_adapter.Type_field.normalize (
+    Atdgen_codec_runtime.Decode.enum
+    [
+        (
+        "A"
+        ,
+          `Decode (
+          read__12
+          |> Atdgen_codec_runtime.Decode.map (fun x -> ((`A x) : _))
+          )
+        )
+    ]
+  )
 )
 let write_a = (
   Atdgen_codec_runtime.Encode.make (fun (t : a) ->

--- a/__tests__/test_bs.mli
+++ b/__tests__/test_bs.mli
@@ -45,6 +45,10 @@ type b = Test_t.b = { thing: int }
 
 type an_array = Test_t.an_array
 
+type adapted_scalar = Test_t.adapted_scalar
+
+type adapted_list = Test_t.adapted_list
+
 type a = Test_t.a = { thing: string; other_thing: bool }
 
 type adapted_kind = Test_t.adapted_kind
@@ -122,6 +126,14 @@ val write_b :  b Atdgen_codec_runtime.Encode.t
 val read_an_array :  an_array Atdgen_codec_runtime.Decode.t
 
 val write_an_array :  an_array Atdgen_codec_runtime.Encode.t
+
+val read_adapted_scalar :  adapted_scalar Atdgen_codec_runtime.Decode.t
+
+val write_adapted_scalar :  adapted_scalar Atdgen_codec_runtime.Encode.t
+
+val read_adapted_list :  adapted_list Atdgen_codec_runtime.Decode.t
+
+val write_adapted_list :  adapted_list Atdgen_codec_runtime.Encode.t
 
 val read_a :  a Atdgen_codec_runtime.Decode.t
 

--- a/__tests__/test_t.ml
+++ b/__tests__/test_t.ml
@@ -41,6 +41,10 @@ type b = { thing: int }
 
 type an_array = int Atdgen_runtime.Util.ocaml_array
 
+type adapted_scalar = [ `A of int | `B of string ]
+
+type adapted_list = [ `A of int list ]
+
 type a = { thing: string; other_thing: bool }
 
 type adapted_kind = [ `A of a | `B of b ]

--- a/__tests__/test_t.mli
+++ b/__tests__/test_t.mli
@@ -41,6 +41,10 @@ type b = { thing: int }
 
 type an_array = int Atdgen_runtime.Util.ocaml_array
 
+type adapted_scalar = [ `A of int | `B of string ]
+
+type adapted_list = [ `A of int list ]
+
 type a = { thing: string; other_thing: bool }
 
 type adapted_kind = [ `A of a | `B of b ]

--- a/src/atdgen_codec_runtime.ml
+++ b/src/atdgen_codec_runtime.ml
@@ -22,12 +22,15 @@ module Json_adapter = struct
       open Param
 
       let normalize (json : Json.t) =
-        let open Json_decode in
-        match json |> (at [type_field_name] string) with
-        | type_ ->
-            let normalized: Json.t = Obj.magic (type_, json) in
-            normalized
-        | exception Invalid_argument _ -> json
+        match json |> Js.Json.classify with
+          | JSONObject obj ->
+            begin match Js.Dict.get obj type_field_name with
+              | Some type_ ->
+                let normalized: Json.t = Obj.magic (type_, json) in
+                normalized
+              | None -> json
+            end
+          | _ -> json
 
       let restore json =
         match json |> Js.Json.classify with


### PR DESCRIPTION
when `Type_field` adapter is used with variant with non-record type, `DecodeError` is occured:
 - `normalize` expects `Dict` https://github.com/ahrefs/bs-atdgen-codec-runtime/blob/master/src/atdgen_codec_runtime.ml#L26) 
 - but `restore` dont modify json structure when type is not `JSONObject` (https://github.com/ahrefs/bs-atdgen-codec-runtime/blob/master/src/atdgen_codec_runtime.ml#L39)

this PR add a fix + tests