### PR TITLE
Report the problem location in terms of the path within the type

### DIFF
--- a/__tests__/errors_test.ml
+++ b/__tests__/errors_test.ml
@@ -33,11 +33,32 @@ let () =
     test "optional field with default: wrong type throws exception" (fun () ->
       let j = Json.parseOrRaise {|{"with_default": "not right"}|} in
       expect (fun () -> Atdgen_codec_runtime.Decode.decode Test_bs.read_optional_field j)
-      |> toThrowException (Json_decode.DecodeError {|Expected number, got "not right"|}));
+      |> toThrowException (Json_decode.DecodeError {|with_default: Expected number, got "not right"|}));
 
     test "optional field: wrong type throws exception" (fun () ->
       let j = Json.parseOrRaise {|{"no_default": "not right"}|} in
       expect (fun () -> Atdgen_codec_runtime.Decode.decode Test_bs.read_optional_field j)
-      |> toThrowException (Json_decode.DecodeError {|Expected number, got "not right"|}));
+      |> toThrowException (Json_decode.DecodeError {|no_default: Expected number, got "not right"|}));
+
+    test "error in variant" (fun () ->
+      let j = Json.parseOrRaise {|["A", "not right"]|} in
+      expect (fun () -> Atdgen_codec_runtime.Decode.decode Test_bs.read_v j)
+      |> toThrowException (Json_decode.DecodeError {|A: Expected number, got "not right"|}));
+
+    test "deeply nested error (array element fails)" (fun () ->
+      let j = Json.parseOrRaise {|["A", [[1, "not right"], "Bool"]]|} in
+      expect (fun () -> Atdgen_codec_runtime.Decode.decode Test_bs.read_deeply_nested j)
+      |> toThrowException (Json_decode.DecodeError {|A.0.1: Expected number, got "not right"|}));
+
+    test "deeply nested error (tuple element fails)" (fun () ->
+      let j = Json.parseOrRaise {|["A", [[1, 2], "Boolean"]]|} in
+      expect (fun () -> Atdgen_codec_runtime.Decode.decode Test_bs.read_deeply_nested j)
+      |> toThrowException (Json_decode.DecodeError {|A.1.Boolean: unknown constructor "Boolean"|}));
+
+    test "deeply nested error (rec_list element fails deep enough)" (fun () ->
+      let j = Json.parseOrRaise {|["A", [[1, 2], ["List", ["Bool", "Fail"]]]]|} in
+      expect (fun () -> Atdgen_codec_runtime.Decode.decode Test_bs.read_deeply_nested j)
+      |> toThrowException (Json_decode.DecodeError {|A.1.List.1.Fail: unknown constructor "Fail"|}));
+
 
   )

--- a/__tests__/test.atd
+++ b/__tests__/test.atd
@@ -86,3 +86,7 @@ type b = {
 }
 
 type an_array = int list <ocaml repr="array">
+
+type deeply_nested = [
+ | A of (an_array * rec_list)
+]

--- a/__tests__/test_bs.ml
+++ b/__tests__/test_bs.ml
@@ -41,9 +41,11 @@ type optional_field = Test_t.optional_field = {
 
 type n = Test_t.n
 
-type b = Test_t.b = { thing: int }
-
 type an_array = Test_t.an_array
+
+type deeply_nested = Test_t.deeply_nested
+
+type b = Test_t.b = { thing: int }
 
 type adapted_scalar = Test_t.adapted_scalar
 
@@ -607,6 +609,55 @@ let write_n = (
 let read_n = (
   read__5
 )
+let write__13 = (
+  Atdgen_codec_runtime.Encode.array (
+    Atdgen_codec_runtime.Encode.int
+  )
+)
+let read__13 = (
+  Atdgen_codec_runtime.Decode.array (
+    Atdgen_codec_runtime.Decode.int
+  )
+)
+let write_an_array = (
+  write__13
+)
+let read_an_array = (
+  read__13
+)
+let write_deeply_nested = (
+  Atdgen_codec_runtime.Encode.make (fun (x : _) -> match x with
+    | `A x ->
+    Atdgen_codec_runtime.Encode.constr1 "A" (
+      Atdgen_codec_runtime.Encode.tuple2
+        (
+          write_an_array
+        )
+        (
+          write_rec_list
+        )
+    ) x
+  )
+)
+let read_deeply_nested = (
+  Atdgen_codec_runtime.Decode.enum
+  [
+      (
+      "A"
+      ,
+        `Decode (
+        Atdgen_codec_runtime.Decode.tuple2
+          (
+            read_an_array
+          )
+          (
+            read_rec_list
+          )
+        |> Atdgen_codec_runtime.Decode.map (fun x -> ((`A x) : _))
+        )
+      )
+  ]
+)
 let write_b = (
   Atdgen_codec_runtime.Encode.make (fun (t : b) ->
     (
@@ -635,22 +686,6 @@ let read_b = (
       } : b)
     )
   )
-)
-let write__13 = (
-  Atdgen_codec_runtime.Encode.array (
-    Atdgen_codec_runtime.Encode.int
-  )
-)
-let read__13 = (
-  Atdgen_codec_runtime.Decode.array (
-    Atdgen_codec_runtime.Decode.int
-  )
-)
-let write_an_array = (
-  write__13
-)
-let read_an_array = (
-  read__13
 )
 let write_adapted_scalar = (
   Atdgen_codec_runtime.Encode.adapter Atdgen_codec_runtime.Json_adapter.Type_field.restore (

--- a/__tests__/test_bs.mli
+++ b/__tests__/test_bs.mli
@@ -41,9 +41,11 @@ type optional_field = Test_t.optional_field = {
 
 type n = Test_t.n
 
-type b = Test_t.b = { thing: int }
-
 type an_array = Test_t.an_array
+
+type deeply_nested = Test_t.deeply_nested
+
+type b = Test_t.b = { thing: int }
 
 type adapted_scalar = Test_t.adapted_scalar
 
@@ -119,13 +121,17 @@ val read_n :  n Atdgen_codec_runtime.Decode.t
 
 val write_n :  n Atdgen_codec_runtime.Encode.t
 
-val read_b :  b Atdgen_codec_runtime.Decode.t
-
-val write_b :  b Atdgen_codec_runtime.Encode.t
-
 val read_an_array :  an_array Atdgen_codec_runtime.Decode.t
 
 val write_an_array :  an_array Atdgen_codec_runtime.Encode.t
+
+val read_deeply_nested :  deeply_nested Atdgen_codec_runtime.Decode.t
+
+val write_deeply_nested :  deeply_nested Atdgen_codec_runtime.Encode.t
+
+val read_b :  b Atdgen_codec_runtime.Decode.t
+
+val write_b :  b Atdgen_codec_runtime.Encode.t
 
 val read_adapted_scalar :  adapted_scalar Atdgen_codec_runtime.Decode.t
 

--- a/__tests__/test_t.ml
+++ b/__tests__/test_t.ml
@@ -37,9 +37,11 @@ type optional_field = {
 
 type n = int option
 
-type b = { thing: int }
-
 type an_array = int Atdgen_runtime.Util.ocaml_array
+
+type deeply_nested = [ `A of (an_array * rec_list) ]
+
+type b = { thing: int }
 
 type adapted_scalar = [ `A of int | `B of string ]
 

--- a/__tests__/test_t.mli
+++ b/__tests__/test_t.mli
@@ -37,9 +37,11 @@ type optional_field = {
 
 type n = int option
 
-type b = { thing: int }
-
 type an_array = int Atdgen_runtime.Util.ocaml_array
+
+type deeply_nested = [ `A of (an_array * rec_list) ]
+
+type b = { thing: int }
 
 type adapted_scalar = [ `A of int | `B of string ]
 

--- a/src/atdgen_codec_runtime.ml
+++ b/src/atdgen_codec_runtime.ml
@@ -1,3 +1,6 @@
+external _unsafeCreateUninitializedArray : int -> 'a array = "Array" [@@bs.new]
+external _stringify : Js.Json.t -> string = "JSON.stringify" [@@bs.val]
+
 open Printf
 
 module Json = struct
@@ -143,16 +146,28 @@ module Encode = struct
 
 end
 
-module Decode =
-struct
+module Decode = struct
 
   include Json_decode
+
+  exception DecodeErrorPath of string list * string
 
   type 'a t = 'a decoder
 
   let make f = f
 
-  let decode f json = f json
+  let decode' f json = f json
+
+  let decode f json =
+    try decode' f json with
+    | DecodeErrorPath (path, msg) ->
+      let path = String.concat "." path in
+      raise (DecodeError {j|$path: $msg|j})
+
+  let with_segment segment f json =
+    try f json with
+    | DecodeError msg -> raise (DecodeErrorPath ([segment], msg))
+    | DecodeErrorPath (path, msg) -> raise (DecodeErrorPath (segment :: path, msg))
 
   let unit j =
     if (Obj.magic j : 'a Js.null) == Js.null
@@ -161,6 +176,126 @@ struct
 
   let int32 j = Int32.of_string (string j)
   let int64 j = Int64.of_string (string j)
+
+  let array decode json = 
+    if Js.Array.isArray json then begin
+      let source = (Obj.magic (json : Js.Json.t) : Js.Json.t array) in
+      let length = Js.Array.length source in
+      let target = _unsafeCreateUninitializedArray length in
+      for i = 0 to length - 1 do
+        let value = 
+          try
+            with_segment (string_of_int i) decode (Array.unsafe_get source i)
+          with
+            DecodeError msg -> raise @@ DecodeError (msg ^ "\n\tin array at index " ^ string_of_int i)
+          in
+        Array.unsafe_set target i value;
+      done;
+      target
+    end
+    else
+      raise @@ DecodeError ("Expected array, got " ^ _stringify json)
+
+  let list decode json =
+    json |> array decode |> Array.to_list
+
+  let pair decodeA decodeB json =
+    if Js.Array.isArray json then begin
+      let source = (Obj.magic (json : Js.Json.t) : Js.Json.t array) in
+      let length = Js.Array.length source in
+      if length = 2 then
+        try
+          with_segment "0" decodeA (Array.unsafe_get source 0),
+          with_segment "1" decodeB (Array.unsafe_get source 1)
+        with
+          DecodeError msg -> raise @@ DecodeError (msg ^ "\n\tin pair/tuple2")
+      else
+        raise @@ DecodeError ({j|Expected array of length 2, got array of length $length|j})
+    end
+    else
+      raise @@ DecodeError ("Expected array, got " ^ _stringify json)
+
+  let tuple2 = pair
+
+  let tuple3 decodeA decodeB decodeC json =
+    if Js.Array.isArray json then begin
+      let source = (Obj.magic (json : Js.Json.t) : Js.Json.t array) in
+      let length = Js.Array.length source in
+      if length = 3 then
+        try
+          with_segment "0" decodeA (Array.unsafe_get source 0),
+          with_segment "1" decodeB (Array.unsafe_get source 1),
+          with_segment "2" decodeC (Array.unsafe_get source 2)
+        with
+          DecodeError msg -> raise @@ DecodeError (msg ^ "\n\tin tuple3")
+      else
+        raise @@ DecodeError ({j|Expected array of length 3, got array of length $length|j})
+    end
+    else
+      raise @@ DecodeError ("Expected array, got " ^ _stringify json)
+
+  let tuple4 decodeA decodeB decodeC decodeD json =
+    if Js.Array.isArray json then begin
+      let source = (Obj.magic (json : Js.Json.t) : Js.Json.t array) in
+      let length = Js.Array.length source in
+      if length = 4 then
+        try
+          with_segment "1" decodeA (Array.unsafe_get source 0),
+          with_segment "2" decodeB (Array.unsafe_get source 1),
+          with_segment "3" decodeC (Array.unsafe_get source 2),
+          with_segment "4" decodeD (Array.unsafe_get source 3)
+        with
+          DecodeError msg -> raise @@ DecodeError (msg ^ "\n\tin tuple4")
+      else
+        raise @@ DecodeError ({j|Expected array of length 4, got array of length $length|j})
+    end
+    else
+      raise @@ DecodeError ("Expected array, got " ^ _stringify json)
+
+  let dict decode json = 
+    if Js.typeof json = "object" && 
+        not (Js.Array.isArray json) && 
+        not ((Obj.magic json : 'a Js.null) == Js.null)
+    then begin
+      let source = (Obj.magic (json : Js.Json.t) : Js.Json.t Js.Dict.t) in
+      let keys = Js.Dict.keys source in
+      let l = Js.Array.length keys in
+      let target = Js.Dict.empty () in
+      for i = 0 to l - 1 do
+          let key = (Array.unsafe_get keys i) in
+          let value =
+            try
+              with_segment key decode (Js.Dict.unsafeGet source key)
+            with
+              DecodeError msg -> raise @@ DecodeError (msg ^ "\n\tin dict")
+            in
+          Js.Dict.set target key value;
+      done;
+      target
+    end
+    else
+      raise @@ DecodeError ("Expected object, got " ^ _stringify json)
+
+  let field key decode json =
+    if 
+      Js.typeof json = "object" && 
+      not (Js.Array.isArray json) && 
+      not ((Obj.magic json : 'a Js.null) == Js.null)
+    then begin
+      let dict =
+        (Obj.magic (json : Js.Json.t) : Js.Json.t Js.Dict.t) in
+      match Js.Dict.get dict key with
+      | Some value -> begin
+        try
+          with_segment key decode value
+        with
+          DecodeError msg -> raise @@ DecodeError (msg ^ "\n\tat field '" ^ key ^ "'")
+        end
+      | None ->
+        raise @@ DecodeError ({j|Expected field '$(key)'|j})
+    end
+    else
+      raise @@ DecodeError ("Expected object, got " ^ _stringify json)
 
   let obj_array f json =
     dict f json
@@ -189,7 +324,7 @@ struct
       | None -> None
       | Some value -> begin
         try
-          Some (decode value)
+          Some (with_segment key decode value)
         with
           DecodeError msg -> raise @@ DecodeError (msg ^ "\n\tat field '" ^ key ^ "'")
         end
@@ -209,7 +344,7 @@ struct
       let length = Js.Array.length source in
       if length = 1 then
         try
-          f (Array.unsafe_get source 0)
+          with_segment "0" f (Array.unsafe_get source 0)
         with
           DecodeError msg -> raise @@ DecodeError (msg ^ "\n\tin tuple1")
       else
@@ -218,22 +353,22 @@ struct
     else
       raise @@ DecodeError ("Expected array, got " ^ (Js.Json.stringify x))
 
-  let enum l =
-    let constr0 x =
-      let s = string x in
+  let enum l json =
+    let constr0 j = let s = string j in `Constr0 s in
+    let constr j = let p = pair string (fun x -> x) j in `Constr p in
+    match either constr0 constr json with
+    | `Constr0 s -> with_segment s (fun () ->
       match List.assoc s l with
       | exception Not_found -> raise @@ DecodeError (sprintf "unknown constructor %S" s)
       | `Single a -> a
       | `Decode _ -> raise @@ DecodeError (sprintf "constructor %S expects arguments" s)
-    in
-    let constr x =
-      let (s,args) = pair string (fun x -> x) x in
+      ) ()
+    | `Constr (s, args) -> with_segment s (fun () ->
       match List.assoc s l with
       | exception Not_found -> raise @@ DecodeError (sprintf "unknown constructor %S" s)
       | `Single _ -> raise @@ DecodeError (sprintf "constructor %S doesn't expect arguments" s)
-      | `Decode d -> decode d args
-    in
-    either constr0 constr
+      | `Decode d -> decode' d args
+      ) ()
 
   let option_as_constr f =
     either

--- a/src/atdgen_codec_runtime.ml
+++ b/src/atdgen_codec_runtime.ml
@@ -159,7 +159,7 @@ module Decode = struct
   let decode' f json = f json
 
   let decode f json =
-    try decode' f json with
+    try f json with
     | DecodeErrorPath (path, msg) ->
       let path = String.concat "." path in
       raise (DecodeError {j|$path: $msg|j})

--- a/yarn.lock
+++ b/yarn.lock
@@ -632,9 +632,9 @@ browser-resolve@^1.11.3:
     resolve "1.1.7"
 
 "bs-platform@>= 4.0.0":
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-5.0.6.tgz#88c13041fb020479800de3d82c680bf971091425"
-  integrity sha512-6Boa2VEcWJp2WJr38L7bp3J929nYha7gDarjxb070jWzgfPJ/WbzjipmSfnu2eqqk1MfjEIpBipbPz6n1NISwA==
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-7.2.2.tgz#76fdc63e4889458ae3d257a0132107a792f2309c"
+  integrity sha512-PWcFfN+jCTtT/rMaHDhKh+W9RUTpaRunmSF9vbLYcrJbpgCNW6aFKAY33u0P3mLxwuhshN3b4FxqGUBPj6exZQ==
 
 bser@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
This PR aims to improve the runtime error reporting when it happens deep inside the nested type.

Consider the `deeply_nested` type definition:
```
type rec_list = [ Bool | List of rec_list list]
type an_array = int list <ocaml repr="array">
type deeply_nested = [
 | A of (an_array * rec_list)
]
```
Now if you try to use its decoder with the json `["A", [[1, 2], ["List", ["Bool", "Fail"]]]]` - you end up with quite cryptic error message (red on the screenshot below):

![image](https://user-images.githubusercontent.com/527503/80608283-d5ea7180-8a36-11ea-8563-3bb1b4d3cd1d.png)

Moreover, in a real case you will have a huge JSON payload which will make the message totally unreadable (at least in browser). All you can read is the very beginning saying: `All decoders given to oneOf failed. Here are all the errors: Expected string, got ...`, but that's absolutely not helpful and even misleading. In fact, that's what I've hit and why I worked on the PR.

The proposed change can be observed on the screenshot above in a green color. Basically, it is narrowing down the path of the problem and displaying it first, followed by the error message. For example: `A.1.List.1.Fail: unknown constructor "Fail"`

Few words to the code itself:
1. It is backward compatible in terms of interface
2. I had to copy-paste a lot from the `bs-json` library. Not proud of it, but it seemed like a low hanging fruit.
3. I've updated the `bs-platform` in the `yarn.lock` to the latest one (hopefully for good)
