### PR TITLE
Treat null fields as missing

### DIFF
--- a/__tests__/decode_test.ml
+++ b/__tests__/decode_test.ml
@@ -1,0 +1,25 @@
+open Jest
+
+let run_decode_test ~name ~read ~data ~expected =
+  let open Expect in
+  let decode = Atdgen_codec_runtime.Decode.decode read in
+  let data' = decode data in
+  test name (fun () -> expect data' |> toEqual expected)
+
+(**
+  atdgen doesn't ever encode a null, but it's quite possible when decoding external data.
+
+  both nullable and optional field null values need to decode to `None`.
+ *)
+let () =
+  describe "JSON decoding tests" (fun () ->
+      run_decode_test ~name:"nullable field decoding a null"
+        ~read:Test_bs.read_optional_field
+        ~expected:
+          { with_default = 9; no_default = None; no_default_nullable = None }
+        ~data:[%raw {|{ no_default_nullable: null }|}];
+      run_decode_test ~name:"optional field decoding a null"
+        ~read:Test_bs.read_optional_field
+        ~expected:
+          { with_default = 9; no_default = None; no_default_nullable = None }
+        ~data:[%raw {|{ no_default: null}|}])

--- a/__tests__/errors_test.ml
+++ b/__tests__/errors_test.ml
@@ -15,17 +15,19 @@ let () =
       let j = Json.parseOrRaise {|{}|} in
       expect (wrap_exn (fun () -> Atdgen_codec_runtime.Decode.(option_as_constr int)j))
       |> toBe (
-        "All decoders given to oneOf failed. Here are all the errors: \
-        [object Object]. And the JSON \
-        being decoded: {}"));
+        "All decoders given to oneOf failed. Here are all the errors: \n\
+         - Expected string, got {}\n\
+         - Expected array, got {}\n\
+         And the JSON being decoded: {}"));
 
     test "enum" (fun () ->
       let j = Json.parseOrRaise {|{}|} in
       expect (wrap_exn (fun () -> Atdgen_codec_runtime.Decode.(enum []) j))
       |> toBe(
-                             "All decoders given to oneOf failed. Here are all the errors: \
-                              [object Object]. And the JSON \
-                              being decoded: {}"));
+        "All decoders given to oneOf failed. Here are all the errors: \n\
+         - Expected string, got {}\n\
+         - Expected array, got {}\n\
+         And the JSON being decoded: {}"));
 
     test "missing field in record" (fun () ->
       let j = Json.parseOrRaise {|{"o": 44}|} in

--- a/__tests__/roundtrip_test.ml
+++ b/__tests__/roundtrip_test.ml
@@ -1,3 +1,5 @@
+(** Test that encoding + decoding a value equals to the original value. *)
+
 open Jest
 
 let run_test ~name ~write ~read ~data =
@@ -11,40 +13,6 @@ let run_test ~name ~write ~read ~data =
     |> toEqual data'
   )
 
-let run_read_test ~name ~read ~data ~expected =
-  let open Expect in
-  let decode = Atdgen_codec_runtime.Decode.decode read in
-  let data' = decode data in
-  test name (fun () ->
-    expect data'
-    |> toEqual expected
-  )
-
-
-(** Test that decoding data that wouldn't normally be encoded still equals the correct value *)
-let () =
-    describe "read tests" (fun () ->
-      run_read_test
-        ~name:"nullable field set to null"
-        ~read:Test_bs.read_optional_field
-        ~expected:{with_default = 9; no_default = None; no_default_nullable = None}
-        ~data:begin
-          let input = Js.Dict.empty () in
-          let () = Js.Dict.set input "no_default_nullable" Js.Json.null in
-          Js.Json.object_ input
-        end;
-      run_read_test
-        ~name:"optional field set to null"
-        ~read:Test_bs.read_optional_field
-        ~expected:{with_default = 9; no_default = None; no_default_nullable = None}
-        ~data:begin
-          let input = Js.Dict.empty () in
-          let () = Js.Dict.set input "no_default" Js.Json.null in
-          Js.Json.object_ input
-        end;
-    )
-
-(** Test that encoding + decoding a value equals to the original value. *)
 let () =
   describe "roundtrip tests" (fun () ->
     run_test

--- a/__tests__/roundtrip_test.ml
+++ b/__tests__/roundtrip_test.ml
@@ -1,5 +1,3 @@
-(** Test that encoding + decoding a value equals to the original value. *)
-
 open Jest
 
 let run_test ~name ~write ~read ~data =
@@ -13,6 +11,40 @@ let run_test ~name ~write ~read ~data =
     |> toEqual data'
   )
 
+let run_read_test ~name ~read ~data ~expected =
+  let open Expect in
+  let decode = Atdgen_codec_runtime.Decode.decode read in
+  let data' = decode data in
+  test name (fun () ->
+    expect data'
+    |> toEqual expected
+  )
+
+
+(** Test that decoding data that wouldn't normally be encoded still equals the correct value *)
+let () =
+    describe "read tests" (fun () ->
+      run_read_test
+        ~name:"nullable field set to null"
+        ~read:Test_bs.read_optional_field
+        ~expected:{with_default = 9; no_default = None; no_default_nullable = None}
+        ~data:begin
+          let input = Js.Dict.empty () in
+          let () = Js.Dict.set input "no_default_nullable" Js.Json.null in
+          Js.Json.object_ input
+        end;
+      run_read_test
+        ~name:"optional field set to null"
+        ~read:Test_bs.read_optional_field
+        ~expected:{with_default = 9; no_default = None; no_default_nullable = None}
+        ~data:begin
+          let input = Js.Dict.empty () in
+          let () = Js.Dict.set input "no_default" Js.Json.null in
+          Js.Json.object_ input
+        end;
+    )
+
+(** Test that encoding + decoding a value equals to the original value. *)
 let () =
   describe "roundtrip tests" (fun () ->
     run_test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahrefs/bs-atdgen-codec-runtime",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "bucklescript runtime for atdgen",
   "main": "src/atdgen_codec_runtime.bs.js",
   "repository": "https://github.com/ahrefs/bs-atdgen-codec-runtime.git",

--- a/src/atdgen_codec_decode.ml
+++ b/src/atdgen_codec_decode.ml
@@ -97,11 +97,7 @@ let tuple4 decodeA decodeB decodeC decodeD json =
   else raise @@ DecodeError ("Expected array, got " ^ Js.Json.stringify json)
 
 let dict decode json =
-  if
-    Js.typeof json = "object"
-    && (not (Js.Array.isArray json))
-    && not (Js.Json.test json Null)
-  then (
+  if Js.Json.test json Object then (
     let source = (Obj.magic (json : Js.Json.t) : Js.Json.t Js.Dict.t) in
     let keys = Js.Dict.keys source in
     let l = Js.Array.length keys in
@@ -118,11 +114,7 @@ let dict decode json =
   else raise @@ DecodeError ("Expected object, got " ^ Js.Json.stringify json)
 
 let field key decode json =
-  if
-    Js.typeof json = "object"
-    && (not (Js.Array.isArray json))
-    && not (Js.Json.test json Null)
-  then
+  if Js.Json.test json Object then
     let dict = (Obj.magic (json : Js.Json.t) : Js.Json.t Js.Dict.t) in
     match Js.Dict.get dict key with
     | Some value -> (
@@ -141,11 +133,7 @@ let nullable decode json =
 
 (* Unlike Json_decode.field, this returns None if key is not found *)
 let fieldOptional key decode json =
-  if
-    Js.typeof json = "object"
-    && (not (Js.Array.isArray json))
-    && not (Js.Json.test json Null)
-  then
+  if Js.Json.test json Object then
     let dict = (Obj.magic (json : Js.Json.t) : Js.Json.t Js.Dict.t) in
     match Js.Dict.get dict key with
     | None -> None

--- a/src/atdgen_codec_decode.ml
+++ b/src/atdgen_codec_decode.ml
@@ -21,7 +21,7 @@ let with_segment segment f json =
       raise (DecodeErrorPath (segment :: path, msg))
 
 let unit j =
-  if (Obj.magic j : 'a Js.null) == Js.null then ()
+  if Js.Json.test j Null then ()
   else raise (DecodeError ("Expected null, got " ^ Js.Json.stringify j))
 
 let int32 j = Int32.of_string (string j)
@@ -100,7 +100,7 @@ let dict decode json =
   if
     Js.typeof json = "object"
     && (not (Js.Array.isArray json))
-    && not ((Obj.magic json : 'a Js.null) == Js.null)
+    && not (Js.Json.test json Null)
   then (
     let source = (Obj.magic (json : Js.Json.t) : Js.Json.t Js.Dict.t) in
     let keys = Js.Dict.keys source in
@@ -121,7 +121,7 @@ let field key decode json =
   if
     Js.typeof json = "object"
     && (not (Js.Array.isArray json))
-    && not ((Obj.magic json : 'a Js.null) == Js.null)
+    && not (Js.Json.test json Null)
   then
     let dict = (Obj.magic (json : Js.Json.t) : Js.Json.t Js.Dict.t) in
     match Js.Dict.get dict key with
@@ -137,14 +137,14 @@ let obj_array f json = dict f json |> Js.Dict.entries
 let obj_list f json = obj_array f json |> Array.to_list
 
 let nullable decode json =
-  if (Obj.magic json : 'a Js.null) == Js.null then None else Some (decode json)
+  if Js.Json.test json Null then None else Some (decode json)
 
 (* Unlike Json_decode.field, this returns None if key is not found *)
 let fieldOptional key decode json =
   if
     Js.typeof json = "object"
     && (not (Js.Array.isArray json))
-    && not ((Obj.magic json : 'a Js.null) == Js.null)
+    && not (Js.Json.test json Null)
   then
     let dict = (Obj.magic (json : Js.Json.t) : Js.Json.t Js.Dict.t) in
     match Js.Dict.get dict key with

--- a/src/atdgen_codec_decode.ml
+++ b/src/atdgen_codec_decode.ml
@@ -137,6 +137,8 @@ let fieldOptional key decode json =
     let dict = (Obj.magic (json : Js.Json.t) : Js.Json.t Js.Dict.t) in
     match Js.Dict.get dict key with
     | None -> None
+    (* treat fields with null values as missing fields (atdgen's default) *)
+    | Some value when (Js.Json.test value Null) -> None
     | Some value -> (
         try Some (with_segment key decode value)
         with DecodeError msg ->

--- a/yarn.lock
+++ b/yarn.lock
@@ -303,9 +303,9 @@
     jest "^26.5.2"
 
 "@glennsl/bs-json@^5.0.0":
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/@glennsl/bs-json/-/bs-json-5.0.2.tgz#cfb85d94d370ec6dc17849e0ddb1a51eee08cfcc"
-  integrity sha512-vVlHJNrhmwvhyea14YiV4L5pDLjqw1edE3GzvMxlbPPQZVhzgO3sTWrUxCpQd2gV+CkMfk4FHBYunx9nWtBoDg==
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@glennsl/bs-json/-/bs-json-5.0.4.tgz#8a80906f3b5e04d78dc06722e5987ff6499c89a8"
+  integrity sha512-Th9DetZjRlMZrb74kgGJ44oWcoFyOTE884WlSuXft0Cd+J09vHRxiB7eVyK7Gthb4cSevsBBJDHYAbGGL25wPw==
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"


### PR DESCRIPTION
While working on #32 I noticed that the code `atdgen` generates for other runtimes defaults to treating null fields as missing. This runtime implementation didn't do that - I think it should. I also took the opportunity to clean up some unnecessary use of `Obj.magic`.